### PR TITLE
Rename Nokia to MixRadio and fix test bat files

### DIFF
--- a/Extensions/MixRadio.Extensions.Win8.csproj
+++ b/Extensions/MixRadio.Extensions.Win8.csproj
@@ -105,12 +105,6 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\MixRadioApi\MixRadio.csproj">
-      <Project>{c2925b4d-2347-473b-908f-5cc79bc717a0}</Project>
-      <Name>Nokia.Music.PCL</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="..\MixRadioApi\Properties\AssemblyInfo.cs">
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
@@ -128,6 +122,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MixRadioApi\MixRadio.csproj">
+      <Project>{c2925b4d-2347-473b-908f-5cc79bc717a0}</Project>
+      <Name>MixRadio</Name>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '12.0' ">
     <VisualStudioVersion>12.0</VisualStudioVersion>

--- a/Extensions/MixRadio.Extensions.Wp8.csproj
+++ b/Extensions/MixRadio.Extensions.Wp8.csproj
@@ -106,12 +106,6 @@
     <Compile Include="TaskExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\MixRadioApi\MixRadio.csproj">
-      <Project>{c2925b4d-2347-473b-908f-5cc79bc717a0}</Project>
-      <Name>Nokia.Music.PCL</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
@@ -132,6 +126,12 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\sl4-windowsphone71\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MixRadioApi\MixRadio.csproj">
+      <Project>{c2925b4d-2347-473b-908f-5cc79bc717a0}</Project>
+      <Name>MixRadio</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).$(TargetFrameworkVersion).Overrides.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).CSharp.targets" />

--- a/Extensions/MixRadio.Extensions.Wp81.csproj
+++ b/Extensions/MixRadio.Extensions.Wp81.csproj
@@ -93,12 +93,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\MixRadioApi\MixRadio.csproj">
-      <Project>{c2925b4d-2347-473b-908f-5cc79bc717a0}</Project>
-      <Name>Nokia.Music.PCL</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="..\MixRadioApi\Properties\AssemblyInfo.cs">
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
@@ -119,6 +113,12 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MixRadioApi\MixRadio.csproj">
+      <Project>{c2925b4d-2347-473b-908f-5cc79bc717a0}</Project>
+      <Name>MixRadio</Name>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '12.0' ">
     <VisualStudioVersion>12.0</VisualStudioVersion>

--- a/RunTests.bat
+++ b/RunTests.bat
@@ -1,3 +1,3 @@
 @echo off
 Call BuildVars.bat
-Build\Nunit.%NUNITVERSION%\bin\nunit-console.exe /noshadow NokiaMusicApiTests\bin\Debug\Nokia.Music.Tests.dll
+Build\Nunit.%NUNITVERSION%\bin\nunit-console.exe /noshadow Tests\bin\Debug\MixRadio.Tests.dll

--- a/RunTestsWithCover.bat
+++ b/RunTestsWithCover.bat
@@ -1,8 +1,8 @@
 @echo off
 Call BuildVars.bat
 .nuget\nuget install OpenCover -version %OPENCOVERVERSION% -o packages
-packages\OpenCover.%OPENCOVERVERSION%\OpenCover.Console.exe -register:user -target:Build\Nunit.%NUNITVERSION%\bin\nunit-console-x86.exe -targetargs:"/noshadow /nodots NokiaMusicApiTests\bin\Debug\Nokia.Music.Tests.dll" -filter:"+[Nokia.Music.Tests]* -[Nokia.Music.Tests]Nokia.Music.Tests* -[Nokia.Music.Tests]Ionic*" -output:TestCoverage.xml
+packages\OpenCover.%OPENCOVERVERSION%\OpenCover.Console.exe -register:user -target:Build\Nunit.%NUNITVERSION%\bin\nunit-console-x86.exe -targetargs:"/noshadow /nodots Tests\bin\Debug\MixRadio.Tests.dll" -filter:"+[MixRadio.Tests]* -[MixRadio.Tests]MixRadio.Tests* -[MixRadio.Tests]Ionic*" -output:TestCoverage.xml
 
 .nuget\nuget install ReportGenerator -version %REPORTGENERATORVERSION% -o packages
-packages\ReportGenerator.%REPORTGENERATORVERSION%\ReportGenerator.exe -reports:TestCoverage.xml -sourcedirs:NokiaMusicApiTests -reporttypes:HTML -targetdir:TestCoverageReport
+packages\ReportGenerator.%REPORTGENERATORVERSION%\ReportGenerator.exe -reports:TestCoverage.xml -sourcedirs:Tests -reporttypes:HTML -targetdir:TestCoverageReport
 Start TestCoverageReport\index.htm

--- a/TestApps/Shared/MixRadio.TestApp.Shared.projitems
+++ b/TestApps/Shared/MixRadio.TestApp.Shared.projitems
@@ -6,7 +6,7 @@
     <SharedGUID>b1301b4d-823a-4953-86ba-55a5c8e9a6c2</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>Nokia.Music.TestApp</Import_RootNamespace>
+    <Import_RootNamespace>MixRadio.TestApp</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)..\ApiKeys.cs" />

--- a/TestApps/Win8/MixRadio.TestApp.Win8.csproj
+++ b/TestApps/Win8/MixRadio.TestApp.Win8.csproj
@@ -174,7 +174,7 @@
     </ProjectReference>
     <ProjectReference Include="..\..\MixRadioApi\MixRadio.csproj">
       <Project>{c2925b4d-2347-473b-908f-5cc79bc717a0}</Project>
-      <Name>Nokia.Music.PCL</Name>
+      <Name>MixRadio</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="..\Shared\MixRadio.TestApp.Shared.projitems" Label="Shared" />

--- a/TestApps/Wp8/MixRadio.TestApp.Wp8.csproj
+++ b/TestApps/Wp8/MixRadio.TestApp.Wp8.csproj
@@ -237,7 +237,7 @@
     </ProjectReference>
     <ProjectReference Include="..\..\MixRadioApi\MixRadio.csproj">
       <Project>{c2925b4d-2347-473b-908f-5cc79bc717a0}</Project>
-      <Name>Nokia.Music.PCL</Name>
+      <Name>MixRadio</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).$(TargetFrameworkVersion).Overrides.targets" />

--- a/TestApps/Wp81/MixRadio.TestApp.Wp81.csproj
+++ b/TestApps/Wp81/MixRadio.TestApp.Wp81.csproj
@@ -143,7 +143,7 @@
     </ProjectReference>
     <ProjectReference Include="..\..\MixRadioApi\MixRadio.csproj">
       <Project>{c2925b4d-2347-473b-908f-5cc79bc717a0}</Project>
-      <Name>Nokia.Music.PCL</Name>
+      <Name>MixRadio</Name>
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '12.0' ">


### PR DESCRIPTION
- Root namespace of shared code projects renamed from `Nokia.Music.TestApp` to `MixRadio.TestApp`.
- Renamed references of projects from `Nokia.Music.PCL` to `MixRadio`.
- Fixed test bat files.